### PR TITLE
fix quill to able to handle struct metadata, rather than crash not logging

### DIFF
--- a/lib/builder/builder.ex
+++ b/lib/builder/builder.ex
@@ -12,24 +12,25 @@ defmodule Quill.Builder do
     |> Map.merge(%{
       name: get_name(config),
       level: level,
-      message: message
-               |> censor_regex(config.custom_censor_regex)
-               |> censor_email(config.email_censor_type)
-               |> censor_phone_number(config.phone_number_censor_type, config.phone_number_prefix),
+      message:
+        message
+        |> censor_regex(config.custom_censor_regex)
+        |> censor_email(config.email_censor_type)
+        |> censor_phone_number(config.phone_number_censor_type, config.phone_number_prefix),
       timestamp: get_formatted_timestamp(timestamp),
-      version: get_version(config),
+      version: get_version(config)
     })
   end
 
   def add_metadata_fields(data, metadata, config) do
     data
-    |> Map.merge(metadata
-                 |> filter_metadata(config)
-                 |> Enum.into(%{})
-                 |> Map.delete(:timestamp))
+    |> Map.merge(
+      metadata
+      |> filter_metadata(config)
+      |> Enum.into(%{})
+      |> Map.delete(:timestamp)
+    )
   end
-
-
 
   def censor_regex(message, nil) do
     message
@@ -68,7 +69,9 @@ defmodule Quill.Builder do
   def censor_phone_number(message, :partial, area_code) do
     "(#{Regex.replace(~r/\+/, area_code, "\\+")})(\\d+)"
     |> Regex.compile!()
-    |> Regex.replace(message, fn _, code, number -> "#{code}***#{String.slice(number, -3..-1)}" end)
+    |> Regex.replace(message, fn _, code, number ->
+      "#{code}***#{String.slice(number, -3..-1)}"
+    end)
   end
 
   def censor_phone_number(message, :full, area_code) do
@@ -76,8 +79,6 @@ defmodule Quill.Builder do
     |> Regex.compile!()
     |> Regex.replace(message, fn _, _, _ -> "***" end)
   end
-
-
 
   defp get_name(config) do
     config.name

--- a/lib/encoder/encoder.ex
+++ b/lib/encoder/encoder.ex
@@ -25,50 +25,52 @@ defmodule Quill.Encoder do
     |> Jason.encode!()
   end
 
-  defp force_map(value) when is_map(value) do
-    Enum.into(value, %{}, 
-              fn {k, v} -> {force_map(k), force_map(v)} end)
-  end
-
-  defp force_map(value) when is_list(value) do
-    Enum.map(value, &force_map/1)
-  end
-
   defp force_map(%{__struct__: _} = value) do
     value
     |> Map.from_struct()
     |> force_map()
   end
 
-  defp force_map(value) when is_pid(value)
-                        when is_port(value)
-                        when is_reference(value)
-                        when is_tuple(value)
-                        when is_function(value), do: inspect(value)
+  defp force_map(value) when is_map(value) do
+    Enum.into(value, %{}, fn {k, v} -> {force_map(k), force_map(v)} end)
+  end
+
+  defp force_map(value) when is_list(value) do
+    Enum.map(value, &force_map/1)
+  end
+
+  defp force_map(value)
+       when is_pid(value)
+       when is_port(value)
+       when is_reference(value)
+       when is_tuple(value)
+       when is_function(value),
+       do: inspect(value)
 
   defp force_map(value), do: value
 
-  defp force_string(value) when is_map(value)
-                           when is_list(value), do: Jason.encode!(force_map(value))
+  defp force_string(value) when is_map(value) when is_list(value),
+    do: Jason.encode!(force_map(value))
 
-  defp force_string(value) when is_pid(value)
-                           when is_port(value)
-                           when is_reference(value)
-                           when is_tuple(value)
-                           when is_function(value), do: inspect(value)
+  defp force_string(value)
+       when is_pid(value)
+       when is_port(value)
+       when is_reference(value)
+       when is_tuple(value)
+       when is_function(value),
+       do: inspect(value)
 
   defp force_string(value), do: value
 
   defp ordered_keywords(value, %{priority_fields: fields}) do
     []
-    |> Keyword.merge(Enum.into(fields, [],
-                               fn f -> {f, force_string(value[f])} end))
-    |> Keyword.merge(Enum.into(Map.drop(value, fields), [],
-                               fn {k, v} -> {k, force_string(v)} end))
+    |> Keyword.merge(Enum.into(fields, [], fn f -> {f, force_string(value[f])} end))
+    |> Keyword.merge(
+      Enum.into(Map.drop(value, fields), [], fn {k, v} -> {k, force_string(v)} end)
+    )
   end
 
   defp ordered_keywords(value, _) do
-    Enum.into(value, [],
-              fn {k, v} -> {k, force_string(v)} end)
+    Enum.into(value, [], fn {k, v} -> {k, force_string(v)} end)
   end
 end

--- a/lib/quill.ex
+++ b/lib/quill.ex
@@ -25,8 +25,6 @@ defmodule Quill do
     {:ok, state}
   end
 
-
-
   def handle_event(:flush, state) do
     {:ok, state}
   end
@@ -35,7 +33,10 @@ defmodule Quill do
     {:ok, state}
   end
 
-  def handle_event({level, _, {Logger, message, timestamp, metadata}}, state = %{level: min_level}) do
+  def handle_event(
+        {level, _, {Logger, message, timestamp, metadata}},
+        state = %{level: min_level}
+      ) do
     if level_priority(level) >= level_priority(min_level) do
       try do
         %{}
@@ -47,10 +48,9 @@ defmodule Quill do
         e -> output_error(e, state)
       end
     end
+
     {:ok, state}
   end
-
-
 
   defp level_priority(:trace), do: 0
   defp level_priority(:debug), do: 10
@@ -74,15 +74,17 @@ defmodule Quill do
       name: "app",
       level: :info,
       io_device: :stdio,
-      priority_fields: [], # Use atoms as prioritized field names
-      log_format: :json, # Valid values are :json or :logfmt
+      # Use atoms as prioritized field names
+      priority_fields: [],
+      # Valid values are :json or :logfmt
+      log_format: :json,
       log_error: true,
       metadata: nil,
       version: 0,
       custom_censor_regex: nil,
       email_censor_type: nil,
       phone_number_censor_type: nil,
-      phone_number_prefix: [],
+      phone_number_prefix: []
     }
   end
 

--- a/test/encoder/encoder_test.exs
+++ b/test/encoder/encoder_test.exs
@@ -1,0 +1,57 @@
+defmodule Quill.EncoderTest do
+  use ExUnit.Case
+
+  test "able to encode normal metadata" do
+    assert "level=error message=\"random test\"" ==
+             Quill.Encoder.encode(
+               %{
+                 level: :error,
+                 message: "random test"
+               },
+               %{log_format: :logfmt, priority_fields: [:level]}
+             )
+  end
+
+  test "able to encode struct metadata" do
+    assert is_binary(
+             Quill.Encoder.encode(
+               %{
+                 level: :error,
+                 message: "random test",
+                 conn: %ConnMock{}
+               },
+               %{log_format: :logfmt, priority_fields: [:level]}
+             )
+           )
+  end
+
+  test "able to encode exception metadata" do
+    assert is_binary(
+             Quill.Encoder.encode(
+               %{
+                 level: :error,
+                 message: "random test",
+                 crash_reason:
+                   {%UndefinedFunctionError{
+                      arity: 0,
+                      function: :undefined,
+                      message: nil,
+                      module: nil,
+                      reason: nil
+                    },
+                    [
+                      {nil, :undefined, [], []},
+                      {EventServiceWeb.HealthController, :health, 2,
+                       [file: 'lib/event_service_web/controllers/health_controller.ex', line: 18]},
+                      {EventServiceWeb.HealthController, :action, 2,
+                       [file: 'lib/event_service_web/controllers/health_controller.ex', line: 1]},
+                      {EventServiceWeb.HealthController, :phoenix_controller_pipeline, 2,
+                       [file: 'lib/event_service_web/controllers/health_controller.ex', line: 1]},
+                      {Phoenix.Router, :__call__, 2, [file: 'lib/phoenix/router.ex', line: 355]}
+                    ]}
+               },
+               %{log_format: :logfmt, priority_fields: [:level]}
+             )
+           )
+  end
+end

--- a/test/quill_test.exs
+++ b/test/quill_test.exs
@@ -1,8 +1,4 @@
 defmodule QuillTest do
   use ExUnit.Case
   doctest Quill
-
-  test "greets the world" do
-    assert Quill.hello() == :world
-  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,5 @@
+defmodule ConnMock do
+  defstruct url: "http://", scheme: :https
+end
+
 ExUnit.start()


### PR DESCRIPTION
currently quill crash when one of the metadata is struct. this shows in particular on phoenix version 1.5.9